### PR TITLE
Aggressively debounce editor changes

### DIFF
--- a/lib/editor.js
+++ b/lib/editor.js
@@ -1,6 +1,7 @@
 'use babel'
 
 import {CompositeDisposable, Emitter} from 'atom'
+import {aggressiveDebounce} from './helpers'
 
 export default class Editor {
   constructor(textEditor, connection) {
@@ -17,14 +18,14 @@ export default class Editor {
     }))
 
     let oldText = null
-    this.subscriptions.add(textEditor.onDidChange(() => {
+    this.subscriptions.add(textEditor.onDidChange(aggressiveDebounce(() => {
       const filePath = textEditor.getPath()
       const fileContents = textEditor.getText()
       if (this.liveReload && oldText !== fileContents) {
         oldText = fileContents
         connection.send('live:save', {path: filePath, contents: fileContents})
       }
-    }))
+    }, 60)))
   }
   getConnection() {
     return this.connection

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -84,3 +84,16 @@ export function debounce(callback, delay) {
     }, delay)
   }
 }
+
+export function aggressiveDebounce(callback, delay) {
+  let timeout = null
+  return function(arg) {
+    if (timeout === null) {
+      timeout = setTimeout(() => {
+        clearTimeout(timeout)
+        timeout = null
+        callback.call(this, arg)
+      }, delay)
+    }
+  }
+}


### PR DESCRIPTION
Number-range does a lot of changes on text editor, half of them unnecessary for us. Therefore we debounce

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/steelbrain/steel-flint/26)

<!-- Reviewable:end -->
