### PR TITLE
Bugfixes for declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3
+
+- Bugfixes for jump between styles and elements
+
 ## 1.0.2
 
 - Add jump between styles and elements

--- a/lib/declarations.js
+++ b/lib/declarations.js
@@ -3,6 +3,7 @@
 /* @flow */
 
 import {CompositeDisposable, Emitter, Range} from 'atom'
+import {createJumpRange} from './helpers'
 import type {TextEditor, Disposable} from 'atom'
 import type {Editor} from './editor'
 import type {Atom$Range, Declarations$Declaration} from './types'
@@ -37,7 +38,7 @@ export class Declarations {
           const stylePosition = view.styles[elementName]
           if (stylePosition) {
             declarations.push({
-              range: element.location,
+              range: createJumpRange(element.location[0], elementName.length),
               source: {
                 filePath: filePath,
                 position: stylePosition.location[0]
@@ -47,11 +48,9 @@ export class Declarations {
         }
         for (const styleName in view.styles) {
           const style = view.styles[styleName]
-          const location = style.location[0]
           const elementPosition = view.els[styleName]
           declarations.push({
-            // $ <-- 1 length for this
-            range: [[location[0], location[1]], [location[0], location[1] + styleName.length + 1]],
+            range: createJumpRange(style.location[0], styleName.length),
             source: {
               filePath: filePath,
               // Fix for $ = {}

--- a/lib/declarations.js
+++ b/lib/declarations.js
@@ -54,7 +54,8 @@ export class Declarations {
             range: [[location[0], location[1]], [location[0], location[1] + styleName.length + 1]],
             source: {
               filePath: filePath,
-              position: elementPosition.location[0]
+              // Fix for $ = {}
+              position: elementPosition && elementPosition.location[0]
             }
           })
         }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -63,3 +63,7 @@ export function getErrorMessage(error: string): string {
   }
   return error
 }
+
+export function createJumpRange(position, length) {
+  return [[position[0], position[1]], [position[0], position[1] + length + 1]]
+}


### PR DESCRIPTION
- Set element range to tag name only instead of entire tag
- Handle `$ = {}` properly
