### PR TITLE
Use linter standard API instead of linter indie API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.4
+
+- Use Linter Standard API instead of Indie API
+
 ## 1.0.3
 
 - Bugfixes for jump between styles and elements

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,12 +9,6 @@ module.exports = {
       description: 'Automatically reload motion page in editor',
       type: 'boolean',
       default: true
-    },
-    lintingDelay: {
-      description: 'Delay for updating lint messages in editor in ms',
-      type: 'integer',
-      minimum: 0,
-      default: 300
     }
   },
   activate() {
@@ -31,10 +25,6 @@ module.exports = {
     ensureUninstalled('flint')
     ensureUninstalled('language-flint')
   },
-  consumeLinter(indieRegistry) {
-    const linter = indieRegistry.register({name: 'Motion'})
-    this.motion.consumeLinter(linter)
-  },
   consumeStatusbar(statusBar) {
     this.motion.consumeStatusbar(statusBar)
   },
@@ -43,6 +33,9 @@ module.exports = {
   },
   provideDeclarations() {
     return this.motion.provideDeclarations()
+  },
+  provideLinter() {
+    return this.motion.provideLinter()
   },
   dispose() {
     this.motion.dispose()

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -10,21 +10,24 @@ import {getErrorMessage} from './helpers'
 import type {Linter$Provider, Linter$Message, Atom$Range} from './types'
 
 export class Linter {
+  name: string;
+  scope: string;
+  lintOnFly: boolean;
   errors: Map<string, ?{message: string, range: Atom$Range}>;
+  grammarScopes: Array<string>;
   subscriptions: CompositeDisposable;
-  linterProvider: Linter$Provider;
-  deferredUpdateMessages: (() => void);
 
-  constructor(linterProvider: Linter$Provider) {
+  constructor() {
+    this.name = 'Motion'
+    this.scope = 'project'
     this.errors = new Map()
+    this.grammarScopes = ['source.js.motion']
     this.subscriptions = new CompositeDisposable()
-    this.linterProvider = linterProvider
-
-    this.subscriptions.add(atom.config.observe('motion.lintingDelay', delay => {
-      this.deferredUpdateMessages = debounce(this.updateMessages, delay)
+    this.subscriptions.add(atom.config.observe('motion.liveReload', lintOnFly => {
+      this.lintOnFly = lintOnFly
     }))
   }
-  updateMessages() {
+  lint(): Array<Object> {
     const messages = []
     for (const [filePath, error] of this.errors) {
       if (error) {
@@ -36,7 +39,7 @@ export class Linter {
         })
       }
     }
-    this.linterProvider.setMessages(messages)
+    return messages
   }
   handleStatus(status: Object, rootDirectory: string) {
     let filePath = status.path || (status.error && (status.error.fileName || status.error.filePath || status.error.file)) || ''
@@ -58,7 +61,6 @@ export class Linter {
     }
     const message = status.error ? getErrorMessage(status.error.message) : null
     this.errors.set(filePath, error)
-    this.deferredUpdateMessages()
   }
   dispose() {
     this.errors.clear()

--- a/lib/main.js
+++ b/lib/main.js
@@ -60,19 +60,6 @@ export class Motion {
     this.projects.activate()
     this.commands.activate()
   }
-  consumeLinter(linterProvider: Linter$Provider) {
-    const subscriptions = new CompositeDisposable()
-    const linter = new Linter(linterProvider)
-    subscriptions.add(linterProvider)
-    subscriptions.add(linter)
-    subscriptions.add(this.connections.onDidReceiveMessage('compile:error', function({message, connection}) {
-      linter.handleStatus(message, connection.getDirectory())
-    }))
-    subscriptions.add(this.connections.onDidReceiveMessage('compile:success', function({message, connection}) {
-      linter.handleStatus(message, connection.getDirectory())
-    }))
-    this.subscriptions.add(subscriptions)
-  }
   consumeStatusbar(statusBar: Object) {
     const statusIcon = new StatusIcon()
     statusIcon.activate(statusBar)
@@ -96,6 +83,19 @@ export class Motion {
     })
     this.subscriptions.add(declarations)
     return declarations
+  }
+  provideLinter(): Linter {
+    const subscriptions = new CompositeDisposable()
+    const linter = new Linter()
+    subscriptions.add(linter)
+    subscriptions.add(this.connections.onDidReceiveMessage('compile:error', function({message, connection}) {
+      linter.handleStatus(message, connection.getDirectory())
+    }))
+    subscriptions.add(this.connections.onDidReceiveMessage('compile:success', function({message, connection}) {
+      linter.handleStatus(message, connection.getDirectory())
+    }))
+    this.subscriptions.add(subscriptions)
+    return linter
   }
   dispose() {
     this.subscriptions.dispose()

--- a/package.json
+++ b/package.json
@@ -24,11 +24,6 @@
     "intentions-numbers"
   ],
   "consumedServices": {
-    "linter-indie": {
-      "versions": {
-        "1.0.0": "consumeLinter"
-      }
-    },
     "status-bar": {
       "versions": {
         "^1.0.0": "consumeStatusbar"
@@ -44,6 +39,11 @@
     "declarations": {
       "versions": {
         "1.0.0": "provideDeclarations"
+      }
+    },
+    "linter": {
+      "versions": {
+        "1.0.0": "provideLinter"
       }
     }
   }


### PR DESCRIPTION
- The user can now choose to disable linting on fly even when live reload is enabled
- The user can configure a lintOnFly delay of their choice
